### PR TITLE
Add kafka_protocol to resolve "undefined function kpro_req_lib:make/3"

### DIFF
--- a/src/flare.app.src
+++ b/src/flare.app.src
@@ -7,7 +7,8 @@
     kernel,
     metal,
     stdlib,
-    shackle
+    shackle,
+    kafka_protocol
   ]},
   {mod, {flare_app, []}},
   {env, []}


### PR DESCRIPTION
* When using flare with Elixir, I found that flare does not function properly.
* Having added kafka_protocol to the list of applications, the kpro_req_lib module will be loaded.

For a stacktrace, please see the related issue: https://github.com/bitwalker/distillery/issues/671